### PR TITLE
Fix warning about wrong DeviceEntryType in homeassistant.helpers.frame

### DIFF
--- a/dwd/weather.py
+++ b/dwd/weather.py
@@ -38,6 +38,7 @@ from homeassistant.const import (
     TEMP_CELSIUS,
 )
 from homeassistant.helpers import sun
+from homeassistant.helpers.device_registry import DeviceEntryType
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from homeassistant.util import dt
 from homeassistant.util.distance import convert as convert_distance
@@ -77,7 +78,7 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
         "name": config_entry.title,
         "manufacturer": "Deutscher Wetterdienst",
         "model": f"Station {config_entry.unique_id}",
-        "entry_type": "service",
+        "entry_type": DeviceEntryType.SERVICE,
     }
 
     async_add_entities(


### PR DESCRIPTION
Fixes a warning regarding a wrong data type of `device_type`:
```
WARNING (MainThread) [homeassistant.helpers.frame] Detected code that uses str for device registry entry_type. This is deprecated and will stop working in Home Assistant 2022.3, it should be updated to use DeviceEntryType instead. Please report this issue.
```