### PR TITLE
Update __init__.py

### DIFF
--- a/custom_components/dwd/__init__.py
+++ b/custom_components/dwd/__init__.py
@@ -64,7 +64,7 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
     hass.data[DOMAIN][config_entry.entry_id] = coordinator
 
     hass.async_create_task(
-        hass.config_entries.async_forward_entry_setup(config_entry, Platform.WEATHER)
+        await hass.config_entries.async_forward_entry_setup(config_entry, Platform.WEATHER)
     )
 
     return True


### PR DESCRIPTION
fix log message:

Detected code that calls async_forward_entry_setup for integration dwd with title: {{title}} and entry_id: {{entry_id}}, during setup without awaiting async_forward_entry_setup, which can cause the setup lock to be released before the setup is done.

this should fix #25 